### PR TITLE
ci(release.yml): only recreate canary once all artifacts are ready to upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,48 +13,16 @@ on:
       - "supply-chain/**"
   workflow_dispatch:
 
+concurrency: ${{ github.workflow }}
+
 env:
   CARGO_TERM_COLOR: always
   RUST_VERSION: 1.68
 
 jobs:
-  reset_canary_release:
-    name: Delete and create Canary Release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: 'Check if canary tag exists'
-        id: canaryExists
-        shell: bash
-        run: |
-          git fetch --prune --unshallow --tags
-          git show-ref --tags --verify --quiet -- "refs/tags/canary" && \
-          echo "canaryExists=0" >> "$GITHUB_OUTPUT" || \
-          echo "canaryExists=1" >> "$GITHUB_OUTPUT"
-
-      - name: Delete canary tag
-        if: steps.canaryExists.outputs.canaryExists == 0
-        uses: dev-drprasad/delete-tag-and-release@v0.2.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: canary
-
-      - name: Recreate canary tag and release
-        uses: ncipollo/release-action@v1.12.0
-        with:
-          tag: canary
-          allowUpdates: true
-          prerelease: true
-          body: |
-            This is a "canary" release of the most recent commits on our main branch. Canary is **not stable**.
-            It is only intended for developers wishing to try out the latest features in platform plugin, some of which may not be fully implemented.
-
   build:
     name: Build platform plugin
     runs-on: ${{ matrix.config.os }}
-    needs: reset_canary_release
     strategy:
       fail-fast: false
       matrix:
@@ -159,7 +127,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v3
         with:
-            name: platform-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
+            name: platform
             path: _dist/platform-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
 
       - name: upload binary to Github release
@@ -170,20 +138,13 @@ jobs:
           file: _dist/platform-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
           tag: ${{ github.ref }}
 
-      - name: upload binary to Github release (canary)
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: _dist/platform-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
-          tag: "canary"
-
   checksums_and_manifests:
     name: generate checksums and manifest
     runs-on: ubuntu-latest
     needs: build
     steps:
-
       - uses: actions/checkout@v3
+
       - name: set the release version (main)
         shell: bash
         run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
@@ -195,11 +156,18 @@ jobs:
 
       - name: download release assets
         uses: actions/download-artifact@v3
+        with:
+          name: platform
 
       - name: generate checksums
         run: |
           ls -lh
-          sha256sum platform*.tar.gz/platform*.tar.gz > checksums-${{ env.RELEASE_VERSION }}.txt
+          sha256sum platform*.tar.gz > checksums-${{ env.RELEASE_VERSION }}.txt
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: platform
+          path: checksums-${{ env.RELEASE_VERSION }}.txt
 
       - name: upload checksums to Github release
         if: startsWith(github.ref, 'refs/tags/v')
@@ -209,21 +177,62 @@ jobs:
           file: checksums-${{ env.RELEASE_VERSION }}.txt
           tag: ${{ github.ref }}
 
-      - name: upload checksums to Github release (canary)
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: checksums-${{ env.RELEASE_VERSION }}.txt
-          tag: "canary"
-
       - name: create plugin manifest
         shell: bash
         run: bash .plugin-manifests/generate-manifest.sh ${{ env.RELEASE_VERSION }} checksums-${{ env.RELEASE_VERSION }}.txt > platform.json
 
-      - name: upload plugin manifest to releases
+      - uses: actions/upload-artifact@v3
+        with:
+          name: platform
+          path: platform.json
+
+      - name: upload plugin manifest to release
         uses: svenstaro/upload-release-action@v2
+        if: startsWith(github.ref, 'refs/tags/v')
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: platform.json
-          tag: ${{ env.RELEASE_VERSION }}
+          tag: ${{ github.ref }}
+
+  reset_canary_release:
+    name: Delete and create Canary Release
+    runs-on: ubuntu-latest
+    needs: checksums_and_manifests
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: download release assets
+        uses: actions/download-artifact@v3
+        with:
+          name: platform
+
+      - name: 'Check if canary tag exists'
+        id: canaryExists
+        shell: bash
+        run: |
+          git fetch --prune --unshallow --tags
+          git show-ref --tags --verify --quiet -- "refs/tags/canary" && \
+          echo "canaryExists=0" >> "$GITHUB_OUTPUT" || \
+          echo "canaryExists=1" >> "$GITHUB_OUTPUT"
+
+      - name: Delete canary tag
+        if: steps.canaryExists.outputs.canaryExists == 0
+        uses: dev-drprasad/delete-tag-and-release@v0.2.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: canary
+          delete_release: true
+
+      - name: Recreate canary tag and release
+        uses: ncipollo/release-action@v1.12.0
+        with:
+          tag: canary
+          allowUpdates: true
+          prerelease: true
+          artifacts: "platform*.tar.gz,platform.json,checksums-canary.txt"
+          commit: ${{ github.sha }}
+          body: |
+            This is a "canary" release of the most recent commits on our main branch. Canary is **not stable**.
+            It is only intended for developers wishing to try out the latest features in platform plugin, some of which may not be fully implemented.


### PR DESCRIPTION
Similar to https://github.com/fermyon/cloud-plugin/pull/85

Run on my fork: https://github.com/vdice/platform-plugin/actions/runs/6189944015