### PR TITLE
bump rustc to 1.73

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ concurrency: ${{ github.workflow }}
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.68
+  RUST_VERSION: 1.73
 
 jobs:
   build:


### PR DESCRIPTION
This matches the RUST_VERSION used in the pull request CI pipeline.