### PR TITLE
chore(.github): pin macos amd64/aarch64 runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
     needs: [lint-rust]
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-14]
     steps:
       # install dependencies
       - name: Install latest Rust stable toolchain
@@ -87,7 +87,7 @@ jobs:
     needs: [lint-rust]
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-14]
     steps:
       # install dependencies
       - name: Install latest Rust stable toolchain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
             targetDir: "target/aarch64-unknown-linux-gnu/release",
           }
           - {
-              os: "macos-latest",
+              os: "macos-13",
               arch: "amd64",
               wasiSDK: "macos",
               extension: "",
@@ -55,13 +55,13 @@ jobs:
               targetDir: "target/release",
             }
           - {
-              os: "macos-latest",
+              os: "macos-14",
               arch: "aarch64",
               wasiSDK: "macos",
               extension: "",
-              buildArgs: "--target aarch64-apple-darwin",
-              target: "aarch64-apple-darwin",
-              targetDir: "target/aarch64-apple-darwin/release/",
+              buildArgs: "",
+              target: "",
+              targetDir: "target/release",
             }
           - {
               os: "windows-latest",


### PR DESCRIPTION
- pin macos amd64 runner to macos-13 (macos-latest has switched to Apple Silicon)
- pin macos aarch64 runner to macos-14 (native build)